### PR TITLE
Refine wording, terminology, and examples in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Improved general grammar and wording of the guidelines.
+- **Guidelines**: Rename the Bash-specific patterns section to `Bash Idioms` and update related wording to describe those patterns as idiomatic Bash practices.
+    - `Bash Idioms`
+
 ## [2026.5.31] - 2026-05-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Improved general grammar and wording of the guidelines.
-- **Guidelines**: Rename the Bash-specific patterns section to `Bash Idioms` and update related wording to describe those patterns as idiomatic Bash practices.
+- **Guidelines**: Rename the Bash-specific patterns section to `Bash Idioms`, update
+  related wording to describe those patterns as idiomatic Bash practices, and expand
+  the section rationale around safety, clarity, performance, consistency, and POSIX
+  portability tradeoffs.
     - `Bash Idioms`
 
 ## [2026.5.31] - 2026-05-31

--- a/TODO.md
+++ b/TODO.md
@@ -5,11 +5,11 @@
 Pages requiring review and improvement (completed pages are highlighted as green):
 
 - [x] Home Page
-- [x] Aesthetics
+- [ ] Aesthetics
 - [ ] Bash Idioms
 - [ ] Common Mistakes
 - [ ] Error Handling
-- [ ] Style
+- [x] Style
 
 Action items for these pages:
 

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@ Pages requiring review and improvement (completed pages are highlighted as green
 
 - [x] Home Page
 - [x] Aesthetics
-- [ ] Bashism
+- [ ] Bash Idioms
 - [ ] Common Mistakes
 - [ ] Error Handling
 - [ ] Style

--- a/docs/guidelines/aesthetics.md
+++ b/docs/guidelines/aesthetics.md
@@ -2,7 +2,7 @@
 
 As mentioned in the [Preface](../index.md#preface), this guide aims to be as objective as possible by providing well-founded reasons for each recommended practice. However, some practices are purely stylistic and may vary based on personal preference or specific project requirements.
 
-This section addresses these aesthetic choices and offers guidelines for maintaining a consistent and visually appealing script. Where applicable, the guidelines will include explanations of their advantages over alternative practices.
+This section addresses these aesthetic choices and offers guidelines for maintaining a consistent, visually appealing script. Where applicable, the guidelines will include explanations of their advantages over alternative practices.
 
 For stylistic guidelines that impact a script's functionality, please refer to this guide's [Style](style.md) section.
 
@@ -28,7 +28,7 @@ In the past, the maximum number of characters per line (CPL) was limited to 80 b
     type: info
 
 - **CPL Limit**: Set a maximum CPL of <u>92 characters</u>.
-    - **Reason**: An 92-character limit balances the historical 80-character standard and the need for more descriptive code. It accommodates longer variable names, comments, and strings without sacrificing readability.
+    - **Reason**: A 92-character limit balances the historical 80-character standard and the need for more descriptive code. It accommodates longer variable names, comments, and strings without sacrificing readability.
 - **Exceptions**: The CPL limit may be exceeded if line splitting _significantly_ reduces readability or negatively impacts the script's structure.
 
 ///
@@ -37,7 +37,7 @@ In the past, the maximum number of characters per line (CPL) was limited to 80 b
     type: tip
 
 - **Readability**: Shorter lines reduce the need for horizontal scrolling and minimize word wrapping issues, which can make all the difference when working with multiple windows simultaneously.
-- **Tool Compatibility**: A shorter CPL ensures that code is displayed uniformly across different development environments, such as code review platforms, IDEs, and terminals. This prevents layout issues and preserves the intended structure.
+- **Tool Compatibility**: A shorter CPL ensures code is displayed consistently across development environments, including code review platforms, IDEs, and terminals. This prevents layout issues and preserves the intended structure.
 
 ///
 
@@ -151,7 +151,7 @@ grep -r "TODO" /path/to/project \
 
 ## Formatting Control Structures
 
-Control structures in Bash, such as `if` statements and `for` or `while` loops can be formatted in several ways. Depending on the context, you can choose between a standard or single-line control structure. In either case, maintaining consistency and readability is key.
+Control structures in Bash, such as `if` statements and `for` or `while` loops, can be formatted in several ways. Depending on the context, you can choose between a standard or single-line control structure. In either case, maintaining consistency and readability is key.
 
 /// admonition | Guidelines
     type: info

--- a/docs/guidelines/bash-idioms.md
+++ b/docs/guidelines/bash-idioms.md
@@ -7,8 +7,11 @@ This section focuses on common Bash idioms, which are Bash-specific patterns, bu
 /// admonition | Why This Matters
     type: tip
 
-- **Efficiency and Availability**: Bash idioms often use built-in functionality instead of external commands or purely [POSIX](https://mywiki.wooledge.org/POSIX)-compliant syntax. By leveraging these features, you can write scripts that execute faster and run consistently on systems where Bash is available.
-- **Readability**: While Bash idioms generally improve readability, some features, such as parameter expansion syntax, may be confusing for beginners. However, the robustness and efficiency they offer make them worth learning.
+- **Safety**: Bash idioms often avoid common shell pitfalls such as word splitting, pathname expansion, unsafe parsing, and accidental reliance on external command behavior.
+- **Clarity**: Bash-native constructs make the script's intent easier to see. For example, `[[ ... ]]`, arrays, parameter expansion, and arithmetic contexts communicate what the script is doing more directly than workarounds built from external commands.
+- **Performance**: Built-ins, keywords, and expansions avoid unnecessary subprocesses, which is especially helpful inside loops or frequently called functions.
+- **Consistency**: Relying on Bash features gives scripts more predictable behavior on systems where Bash is the target shell, instead of depending on differences between external tools or POSIX-compatible fallbacks.
+- **Portability Tradeoff**: These patterns may not work in POSIX `sh`. Use them when the script is intentionally written for Bash, and use POSIX-compatible syntax only when `/bin/sh` portability is an explicit requirement.
 
 ///
 

--- a/docs/guidelines/bash-idioms.md
+++ b/docs/guidelines/bash-idioms.md
@@ -1,12 +1,16 @@
-# Bashisms
+# Bash Idioms
 
 As a reminder, this style guide is designed specifically for Bash scripting. When given a choice, <mark>**_ALWAYS_**</mark> prefer Bash built-ins or keywords over external commands or `sh(1)` syntax.
 
-This section focuses on common Bashisms, which are shell features or commands unique to Bash. Using these Bash-specific constructs can improve your scripts' efficiency, portability (1), readability (2), and robustness.
-{ .annotate }
+This section focuses on common Bash idioms, which are Bash-specific patterns, built-ins, keywords, and expansions that improve script safety, readability, performance, and maintainability. These idioms are preferred when writing Bash scripts, but they may not be portable to POSIX `sh`.
 
-1. **Efficiency and Portability**: Bashisms provide built-in functionalities that are more efficient and portable than external commands or purely [POSIX](https://mywiki.wooledge.org/POSIX)-compliant syntax. By leveraging these features, you can write scripts that execute faster and run on any system where Bash is available, without relying on external tools.
-2. **Readability**: While Bashisms generally improve readability, some features, such as the parameter expansion syntax, may be confusing for beginners. However, the robustness and efficiency they offer make them worth learning.
+/// admonition | Why This Matters
+    type: tip
+
+- **Efficiency and Availability**: Bash idioms often use built-in functionality instead of external commands or purely [POSIX](https://mywiki.wooledge.org/POSIX)-compliant syntax. By leveraging these features, you can write scripts that execute faster and run consistently on systems where Bash is available.
+- **Readability**: While Bash idioms generally improve readability, some features, such as parameter expansion syntax, may be confusing for beginners. However, the robustness and efficiency they offer make them worth learning.
+
+///
 
 ## Conditional Tests
 
@@ -375,7 +379,6 @@ fi
 ## Parameter Expansion
 
 [Parameter expansion](https://mywiki.wooledge.org/BashGuide/Parameters#Parameter_Expansion) in Bash allows you to manipulate variables and perform string operations directly within the shell. It offers a wide range of options, including substring extraction, string replacement, and transformations.
-{ .annotate }
 
 /// admonition | Guidelines
     type: info

--- a/docs/guidelines/style.md
+++ b/docs/guidelines/style.md
@@ -26,7 +26,7 @@ echo "Hello, $name"
 //// tab | Single Quotes (`'`)
 
 - **String Literals**: Use single quotes to define string literals.
-    - **Reason**: Single quotes preserve the literal value of every character in a string, preventing the shell from performing expansions or substitutions. This behavior is essential for commands like `find`, `grep`, and `awk`, which have their own rules for interpreting special characters. Using single quotes ensures that these commands receive the input exactly as written, without modification by the shell.
+    - **Reason**: Single quotes preserve the literal value of every character in a string, preventing the shell from performing expansions or substitutions. This behavior is essential for commands such as `find`, `grep`, and `awk`, each of which has its own rules for interpreting special characters. Using single quotes ensures that these commands receive the input exactly as written, without the shell modifying it.
 
 ///// admonition | Example
     type: example
@@ -34,7 +34,8 @@ echo "Hello, $name"
 _Literal string_:
 
 ```bash
-echo '${C_BLUE}This is a literal ${string} with no variable substitution${C_NC}'
+string="cat"
+echo 'This is a literal ${string} with no variable substitution or command expansion.'
 ```
 
 ---
@@ -51,7 +52,7 @@ find . -name '*.txt' -exec grep 'pattern.*here' {} \; -print
 
 - **When to Omit Quotes**: In certain cases, quotes can be safely omitted without risk. Common scenarios include arithmetic operations and double bracket tests.
     - **Arithmetic Operations (`$(( ... ))`)**: [Arithmetic expansion](https://mywiki.wooledge.org/ArithmeticExpression) treats the content as a single unit, preventing word splitting and globbing.
-    - **Double Bracket Tests `[[ ... ]]`**: The `[[ ... ]]` syntax is a Bash built-in that protects against word splitting and globbing, allowing comparisons and checks without the need for quotes.
+    - **Double Bracket Tests `[[ ... ]]`**: The `[[ ... ]]` syntax is a Bash built-in that protects against word splitting and globbing, allowing comparisons and checks without quotes.
 
 ///// admonition | Example
     type: example
@@ -79,7 +80,7 @@ fi
 
 ## Declaring and Naming Variables
 
-Bash offers several methods for declaring variables, each with implications for scope, immutability, and readability. Following best practices for naming and declaring variables is essential to maintain consistency and avoid unintended side effects
+Bash offers several methods for declaring variables, each with implications for scope, immutability, and readability. Following best practices for naming and declaring variables is essential to maintain consistency and avoid unintended side effects.
 
 /// admonition | Guidelines
     type: info
@@ -92,21 +93,23 @@ Bash offers several methods for declaring variables, each with implications for 
 
         1. **Variable Scope**: In Bash, variables declared inside a function without the `local` keyword are global by default, meaning they persist beyond the function's scope and can impact other parts of the script.
 
-    - **Example**:
-        ```bash
-        my_var="global value"
+///// admonition | Example
+    type: example
 
-        my_function() {
-            # This local variable won't overwrite the global variable.
-            local my_var="local value"
-            echo "$my_var"
-        }
+```bash
+my_var="global value"
 
-        my_function
-        echo "$my_var"
-        ```
-        **Explanation**: In this example, `my_var` is defined both globally and locally within `my_function`. The `local` keyword ensures that the `my_var` inside the function is distinct from the global `my_var`. When the function is called, it outputs the local value, whereas the final `echo` statement outputs the global value.
+my_function() {
+    # This local variable won't overwrite the global variable.
+    local my_var="local value"
+    echo "$my_var"
+}
 
+my_function
+echo "$my_var"
+```
+
+/////
 ////
 //// tab | Constant Variables
 
@@ -114,9 +117,9 @@ Bash offers several methods for declaring variables, each with implications for 
     - **Reason**: This naming convention helps distinguish constants from other variables and aligns with common practices across various programming languages. (1)
         { .annotate }
 
-        1. **Constants and Environment Variables**: Constants typically use `UPPER_SNAKE_CASE`, a standard followed in many languages, such as C, Python, and Java. Adopting a common convention ensures that other developers can easily recognize constants in your scripts. However, in Unix-like systems, environment variables are also written in `UPPER_SNAKE_CASE`. To prevent confusion, a prefix such as `C_` is used to differentiate constants from environment variables.
+        1. **Constants and Environment Variables**: Constants typically use `UPPER_SNAKE_CASE`, a standard followed in many languages, such as C, Python, and Java. Adopting a common convention ensures that other developers can easily recognize constants in your scripts. However, in Unix-like systems, environment variables are also written in `UPPER_SNAKE_CASE`. To prevent confusion and accidental overwrites, a prefix such as `C_` is used to differentiate constants from environment variables.
 
-    - **Alternative Prefix**: While `C_` is the default prefix for constants, other prefixes like `CONST_` or `CONFIG_` may be used if they better suit your naming conventions or project requirements. The key is to maintain consistency within your script or project.
+    - **Alternative Prefix**: While `C_` is the default prefix for constants, other prefixes may be used if they better suit your naming conventions or project requirements. The key is to maintain consistency within your script or project.
         - **Example**: The [oh-my-zsh project](https://github.com/ohmyzsh/ohmyzsh) uses the `OMZ_` prefix to clearly indicate constants as part of the project while following the `UPPER_SNAKE_CASE` convention.
 
 - **Selective Use of `readonly`**: Use `readonly` to define constants that must remain unchanged throughout the script.
@@ -180,13 +183,11 @@ perform_operation
 ////
 //// tab | Exported Variables
 
-<!-- TODO: Come back and update wording for 'Reason' and annotation. -->
-
 - **Naming Conventions**: Use `UPPER_SNAKE_CASE` with an `E_` prefix for exported variables (e.g., `E_PATH`).
     - **Reason**: This naming convention differentiates exported variables from other variable types and aligns with the Unix naming convention for environment variables. (1)
         { .annotate }
 
-        1. **Exported and Environment Variables**: Under Unix conventions, environment variables are written in `UPPER_SNAKE_CASE`. However, just like constants, using the same naming convention for exported variables can cause confusion and lead to accidental modifications of existing environment variables. A prefix such as `E_` is used to differentiate exported variables from others while adhering to the `UPPER_SNAKE_CASE` convention.
+        1. **Exported and Environment Variables**: Under Unix conventions, environment variables are written in `UPPER_SNAKE_CASE`. However, as with constants, using the same naming convention for exported variables can cause confusion and lead to accidental modification of existing environment variables. To prevent this, a prefix such as `E_` is used to clearly indicate that the variable is intended for export, distinguishing it from both constants and regular variables.
 
 - **Declaration**: Use `export` when initializing an exported variable or immediately afterward.
 
@@ -198,8 +199,7 @@ perform_operation
 export PATH="$HOME/.local/bin/"
 
 ## Does NOT overwrite the existing $PATH environment variable.
-E_PATH="$HOME/.local/bin/"
-export E_PATH
+export E_PATH="$HOME/.local/bin/"
 ```
 
 /////
@@ -208,8 +208,8 @@ export E_PATH
 
 <!-- TODO: Re-review the wording of the below guidelines. -->
 
-- **Selective Use**: Use the `declare` command to manage advanced variable attributes, such as associative arrays. For simple variable declarations, or when keywords like `local` and `readonly` are sufficient, avoid using `declare`.
-    - **Reason**: The `declare` command is useful for managing complex variable types, such as associative arrays, or when specific attributes are needed. However, using `declare` for basic variable assignments can reduce readability and is often unnecessary.
+- **Selective Use**: Use `declare` to set or manage advanced variable attributes, such as associative arrays. For simple variable declarations, or when keywords like `local` and `readonly` are sufficient, avoid using `declare`.
+    - **Reason**: `declare` is useful when a variable needs explicit Bash attributes. However, using `declare` for basic variable assignments adds noise and can reduce readability.
 
 ///// details | Example
     type: example


### PR DESCRIPTION
This pull request makes several improvements to the Bash scripting guidelines documentation, focusing on grammar, clarity, and consistency. It also renames and expands the Bash-specific patterns section, updates naming conventions, and clarifies rationale for various best practices.

**Documentation and Guidelines Improvements:**

* Improved general grammar and wording throughout the guidelines for clarity and consistency. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R17) [[2]](diffhunk://#diff-d910adc2ea32a4f075f44d581327d3f80d3cc1753a7be1a86dab4d741cefe9dbL5-R5) [[3]](diffhunk://#diff-d910adc2ea32a4f075f44d581327d3f80d3cc1753a7be1a86dab4d741cefe9dbL31-R31) [[4]](diffhunk://#diff-d910adc2ea32a4f075f44d581327d3f80d3cc1753a7be1a86dab4d741cefe9dbL40-R40) [[5]](diffhunk://#diff-d910adc2ea32a4f075f44d581327d3f80d3cc1753a7be1a86dab4d741cefe9dbL154-R154) F676302cL5R5, [[6]](diffhunk://#diff-03efa455b6dab9f1c65c9188c14559f594db952c316976f84c8e0561474114e1L54-R55) [[7]](diffhunk://#diff-03efa455b6dab9f1c65c9188c14559f594db952c316976f84c8e0561474114e1L82-R83) [[8]](diffhunk://#diff-03efa455b6dab9f1c65c9188c14559f594db952c316976f84c8e0561474114e1L211-R212)
* Renamed the `Bashism` section and file to `Bash Idioms`, updated related wording to describe these as idiomatic Bash practices, and expanded the rationale to cover safety, clarity, performance, consistency, and POSIX portability tradeoffs. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R17) [[2]](diffhunk://#diff-5c6a1301c6b59b30a040d747d065e861d3dd98bde0e5a4356d92d594e9835986L8-R12) [[3]](diffhunk://#diff-944675ad1912cc57cae7ea8de61b8c54d2dd7ceb0d1767b31e24fa745978ea37L1-R16) [[4]](diffhunk://#diff-944675ad1912cc57cae7ea8de61b8c54d2dd7ceb0d1767b31e24fa745978ea37L378)
* Updated the `TODO.md` to reflect the renaming of the Bash-specific section and the completion status of various guideline pages.

**Variable Naming and Declaration Clarifications:**

* Clarified and expanded the rationale for naming conventions for constants (`C_` prefix) and exported variables (`E_` prefix), emphasizing the prevention of accidental overwrites and confusion with environment variables. [[1]](diffhunk://#diff-03efa455b6dab9f1c65c9188c14559f594db952c316976f84c8e0561474114e1L108-R122) [[2]](diffhunk://#diff-03efa455b6dab9f1c65c9188c14559f594db952c316976f84c8e0561474114e1L183-R190)
* Improved examples and explanations for variable declaration, scope, and the use of `declare`, `local`, and `readonly`. [[1]](diffhunk://#diff-03efa455b6dab9f1c65c9188c14559f594db952c316976f84c8e0561474114e1L95-R98) [[2]](diffhunk://#diff-03efa455b6dab9f1c65c9188c14559f594db952c316976f84c8e0561474114e1L201-R202) [[3]](diffhunk://#diff-03efa455b6dab9f1c65c9188c14559f594db952c316976f84c8e0561474114e1L211-R212)

**Section-Specific Wording and Example Updates:**

* Enhanced examples and explanations for quoting, line length, control structures, and when to omit quotes for improved readability and accuracy. [[1]](diffhunk://#diff-d910adc2ea32a4f075f44d581327d3f80d3cc1753a7be1a86dab4d741cefe9dbL31-R31) [[2]](diffhunk://#diff-d910adc2ea32a4f075f44d581327d3f80d3cc1753a7be1a86dab4d741cefe9dbL40-R40) [[3]](diffhunk://#diff-d910adc2ea32a4f075f44d581327d3f80d3cc1753a7be1a86dab4d741cefe9dbL154-R154) F676302cL5R5, [[4]](diffhunk://#diff-03efa455b6dab9f1c65c9188c14559f594db952c316976f84c8e0561474114e1L54-R55) [[5]](diffhunk://#diff-03efa455b6dab9f1c65c9188c14559f594db952c316976f84c8e0561474114e1L95-R98) [[6]](diffhunk://#diff-03efa455b6dab9f1c65c9188c14559f594db952c316976f84c8e0561474114e1L201-R202)

These changes together improve the overall quality, maintainability, and clarity of the Bash scripting guidelines documentation.